### PR TITLE
Link LAPACK and BLAS with RcppArmadillo.

### DIFF
--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -1,5 +1,5 @@
 ## -*- mode: makefile; -*-
 CXX_STD = @CXXSTD@
 CXX_STD=CXX17
-
+PKG_LIBS = $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS)
 

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -2,3 +2,4 @@
 CXX_STD = @CXXSTD@
 CXX_STD=CXX17
 fsanitize=undefined
+PKG_LIBS = $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS)


### PR DESCRIPTION
With the current version of RcppArmadillo on CRAN, this package fails to build on Windows because it needs a BLAS routine. According to RcppArmadillo documentation, packages need to link against LAPACK as BLAS (e.g. via Makevars). This patch does that, following that documentation, and it fixes the problem. It would be great if this could be fixed in the package and a new version submitted to CRAN.